### PR TITLE
增加滑动阈值判断

### DIFF
--- a/src/js.fullpage.js
+++ b/src/js.fullpage.js
@@ -15,6 +15,7 @@
         loop: false,
         drag: false,
         dir: 'v',
+        der: 0.1,
         change: function(data) {},
         beforeChange: function(data) {},
         afterChange: function(data) {},
@@ -120,8 +121,8 @@
                 return 0;
             }
 
-            var sub = that.o.dir === 'v' ? e.changedTouches[0].pageY - that.startY : e.changedTouches[0].pageX - that.startX;
-            var der = (sub > 30 || sub < -30) ? sub > 0 ? -1 : 1 : 0;
+            var sub = that.o.dir === 'v' ? (e.changedTouches[0].pageY - that.startY)/that.height : (e.changedTouches[0].pageX - that.startX)/that.width;
+            var der = (sub > that.o.der || sub < -that.o.der) ? sub > 0 ? -1 : 1 : 0;
 
             that.moveTo(that.curIndex + der, true);
         });


### PR DESCRIPTION
原来的判断是滑动30px就翻页
在drag为false时没有什么问题
但在为true时,有时用户翻到一半又想退回来,必须退回到与touchstart相差30px范围内才能放弃翻页,实际验证在大屏上成功概率很低(背景公用,页与页之间间隙很难判断).
所以增加了一个自定义阈值,个人建议初始化时drag为true时设为0.2(20%),drag为false或者dir为h时设为0.1(20%)
